### PR TITLE
Alternative tweak encoding

### DIFF
--- a/.github/workflows/ci-hash-sig.yaml
+++ b/.github/workflows/ci-hash-sig.yaml
@@ -29,7 +29,7 @@ jobs:
           cache-on-failure: true
 
       - name: Run test
-        run: cargo test -- --nocapture
+        run: cargo test --release -- --nocapture
 
   lint:
     name: Lint

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/target
 .vscode
+report

--- a/circuit/openvm/bench.sh
+++ b/circuit/openvm/bench.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+measure_peak_memory() {
+    OS=$(uname -s)
+
+    if [ $OS = 'Darwin' ]; then V='B '; fi
+    AWK_SCRIPT="{ split(\"${V}kB MB GB TB\", v); s=1; while(\$1>1024 && s<9) { \$1/=1024; s++ } printf \"%.2f %s\", \$1, v[s] }"
+
+    printf '%s' 'peak mem: '
+    if [ $OS = 'Darwin' ]; then
+        $(which time) -l "$@" 2>&1 | grep 'maximum resident set size' | grep -E -o '[0-9]+' | awk "$AWK_SCRIPT"
+    else
+        $(which time) -f '%M' "$@" 2>&1 | grep -E -o '^[0-9]+' | awk "$AWK_SCRIPT"
+    fi
+}
+
+mkdir -p report
+
+for R in 1 2 3; do for T in 4 8 16 24; do
+    export RAYON_NUM_THREADS=$T
+    OUTPUT="report/r${R}_t${T}"
+    RUN="cargo run --quiet --profile bench --example hash-sig-agg -- --log-signatures 13 --log-blowup $R"
+    $RUN > $OUTPUT
+    measure_peak_memory $RUN >> $OUTPUT
+done done

--- a/circuit/openvm/render_table.py
+++ b/circuit/openvm/render_table.py
@@ -1,0 +1,19 @@
+print("| `R` | `T` | `PT` | `TP` | `PS` | `PM` | `VT` |")
+print("| - | - | - | - | - | - | - |")
+for i, r in enumerate([1, 2, 3]):
+    if i != 0:
+        print("| | | | | | | |")
+    for t in [4, 8, 16, 24]:
+        try:
+            path = f"report/r{r}_t{t}"
+            lines = open(path).readlines()
+            if len(lines) != 13:
+                raise Exception
+            report = [lines[k].strip().split(": ")[1] for k in [0, 9, 10, 11, 12]]
+        except Exception:
+            report = ["-", "-", "-", "-", "-"]
+        (time, throughput, proof_size, verifying_time, peak_mem) = report
+        throughput = throughput.split(" ")[0]
+        print(
+            f"| `{r}` | `{t}` | `{time}` | `{throughput}` | `{proof_size}` | `{peak_mem}` | `{verifying_time}` |"
+        )

--- a/circuit/openvm/src/gadget/cycle_int.rs
+++ b/circuit/openvm/src/gadget/cycle_int.rs
@@ -2,7 +2,7 @@ use crate::{
     gadget::{is_equal::IsEqualCols, not},
     util::field::MaybeUninitField,
 };
-use core::mem::MaybeUninit;
+use core::{mem::MaybeUninit, ops::Deref};
 use p3_air::AirBuilder;
 use p3_field::{Field, FieldAlgebra};
 
@@ -11,6 +11,15 @@ use p3_field::{Field, FieldAlgebra};
 pub struct CycleInt<T, const N: usize> {
     pub step: T,
     pub is_last_step: IsEqualCols<T>,
+}
+
+impl<T, const N: usize> Deref for CycleInt<T, N> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.step
+    }
 }
 
 impl<T: Field, const N: usize> CycleInt<MaybeUninit<T>, N> {

--- a/circuit/openvm/src/poseidon2/chip/chain/mod.rs
+++ b/circuit/openvm/src/poseidon2/chip/chain/mod.rs
@@ -12,6 +12,7 @@ use openvm_stark_backend::{
     Chip, ChipUsageGetter,
 };
 use p3_commit::PolynomialSpace;
+use p3_field::FieldAlgebra;
 use std::sync::Arc;
 
 const MAX_CHAIN_STEP_DIFF_BITS: usize = (NUM_CHUNKS / 2).next_power_of_two().ilog2() as usize;
@@ -29,14 +30,16 @@ mod poseidon2 {
 pub struct ChainChip<'a> {
     air: Arc<ChainAir>,
     extra_capacity_bits: usize,
+    epoch: u32,
     traces: &'a [VerificationTrace],
 }
 
 impl<'a> ChainChip<'a> {
-    pub fn new(extra_capacity_bits: usize, traces: &'a [VerificationTrace]) -> Self {
+    pub fn new(extra_capacity_bits: usize, epoch: u32, traces: &'a [VerificationTrace]) -> Self {
         Self {
             air: Default::default(),
             extra_capacity_bits,
+            epoch,
             traces,
         }
     }
@@ -70,7 +73,7 @@ where
             raw: AirProofRawInput {
                 cached_mains: Vec::new(),
                 common_main: Some(generate_trace_rows(self.extra_capacity_bits, self.traces)),
-                public_values: Vec::new(),
+                public_values: vec![F::from_canonical_u32(self.epoch << 2)],
             },
         }
     }

--- a/circuit/openvm/src/poseidon2/chip/merkle_tree/generation.rs
+++ b/circuit/openvm/src/poseidon2/chip/merkle_tree/generation.rs
@@ -199,7 +199,7 @@ fn generate_trace_rows_path(
             }
             let input = concat_array![
                 trace.pk.parameter,
-                encode_tweak_merkle_tree(level as u32 + 1, epoch_dec >> 1),
+                encode_tweak_merkle_tree(level as u8 + 1, epoch_dec >> 1),
                 if is_right {
                     [sibling, node].into_iter().flatten()
                 } else {

--- a/circuit/openvm/src/poseidon2/chip/mod.rs
+++ b/circuit/openvm/src/poseidon2/chip/mod.rs
@@ -47,7 +47,7 @@ where
         .map(|(pk, sig)| VerificationTrace::generate(vi.epoch, encoded_msg, pk, sig))
         .collect::<Vec<_>>();
     let main = MainChip::new(extra_capacity_bits, &traces);
-    let chain = ChainChip::new(extra_capacity_bits, &traces);
+    let chain = ChainChip::new(extra_capacity_bits, vi.epoch, &traces);
     let merkle_tree = MerkleTreeChip::new(extra_capacity_bits, vi.epoch, encoded_msg, &traces);
     let decomposition = DecompositionChip::new(extra_capacity_bits, &traces);
     let ((main_api, chain_api), (merkle_tree_api, (decomposition_api, range_check_mult))) = join(

--- a/hash-sig/Cargo.lock
+++ b/hash-sig/Cargo.lock
@@ -361,6 +361,7 @@ dependencies = [
 name = "hash-sig-verifier"
 version = "0.1.0"
 dependencies = [
+ "hashsig",
  "num-bigint",
  "p3-baby-bear",
  "p3-field",
@@ -372,6 +373,17 @@ dependencies = [
  "serde",
  "serde-big-array",
  "sha3",
+]
+
+[[package]]
+name = "hashsig"
+version = "0.1.0"
+source = "git+https://github.com/han0110/hash-sig?branch=feature%2Falt-tweak-encoding#cbdf69ea68a246c4912cf7ff84c633b5d9262518"
+dependencies = [
+ "num-bigint",
+ "rand",
+ "sha3",
+ "zkhash",
 ]
 
 [[package]]

--- a/hash-sig/Cargo.lock
+++ b/hash-sig/Cargo.lock
@@ -155,9 +155,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.13"
+version = "1.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
+checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
 dependencies = [
  "shlex",
 ]
@@ -242,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 
 [[package]]
 name = "ff"
@@ -378,10 +378,11 @@ dependencies = [
 [[package]]
 name = "hashsig"
 version = "0.1.0"
-source = "git+https://github.com/han0110/hash-sig?branch=feature%2Falt-tweak-encoding#cbdf69ea68a246c4912cf7ff84c633b5d9262518"
+source = "git+https://github.com/han0110/hash-sig?branch=feature%2Falt-tweak-encoding#800059fb8e07ef9e22904ccdb8889109017da8b5"
 dependencies = [
  "num-bigint",
  "rand",
+ "rayon",
  "sha3",
  "zkhash",
 ]
@@ -444,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "memuse"
@@ -834,9 +835,9 @@ checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
@@ -852,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1003,15 +1004,15 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "version_check"

--- a/hash-sig/Cargo.toml
+++ b/hash-sig/Cargo.toml
@@ -38,6 +38,7 @@ serde = "1"
 serde-big-array = "0.5.1"
 sha3 = "0.10.8"
 zkhash = { git = "https://github.com/HorizenLabs/poseidon2", branch = "main", package = "zkhash" }
+hashsig = { git = "https://github.com/han0110/hash-sig", branch = "feature/alt-tweak-encoding" }
 
 hash-sig-verifier = { path = "hash-sig-verifier" }
 hash-sig-testdata = { path = "hash-sig-testdata" }

--- a/hash-sig/hash-sig-verifier/Cargo.toml
+++ b/hash-sig/hash-sig-verifier/Cargo.toml
@@ -18,3 +18,6 @@ rand = { workspace = true }
 serde = { workspace = true }
 serde-big-array = { workspace = true }
 sha3 = { workspace = true }
+
+[dev-dependencies]
+hashsig = { workspace = true }


### PR DESCRIPTION
Instead of doing:

```rust
const P = 2^31 - 2^27 + 1;

// chain (ep: u32, i: u16, k: u16)
let tweak = ep<<40 | i<<24 | k<<8 | 2;

// merkle tree (l: u16, i: u32)
let tweak = l<<40 | i<<8 | 1;

// msg (ep: u32)
let tweak = ep<<8 | 0;

let tweak_fe = [tweak % P, tweak / P];
```

The alternative encoding does:

```rust
const P = 2^31 - 2^27 + 1;

// chain (ep: u32, i: u16, k: u16)
let tweak = i*P<<16 | k*P | ep<<2 | 2;

// merkle tree (l: u8, i: u32)
let tweak = i*P | l<<2 | 1;

// msg (ep: u32)
let tweak = ep<<2 | 0;

let tweak_fe = [tweak % P, tweak / P];
```

So in circuit checking twean encoding becomes some lienar constraints.